### PR TITLE
[Bug] Handle the memory delete after used

### DIFF
--- a/proj_cpga/main.cpp
+++ b/proj_cpga/main.cpp
@@ -74,10 +74,15 @@ int main(int argc, char* argv[])
             coursesScore[cnt2] = score;
         }
         assignCourseScore(&items[cnt], numCourses, coursesScore);
+        delete coursesScore;
+        coursesScore = nullptr;
     }
 
     float cgpa = calcCgpa(items, total_semester_num);
     cout << "CGPA: " << cgpa << setprecision(4);
+
+    delete items;
+    items = nullptr;
 
     return 0;
 }


### PR DESCRIPTION
# Handle memory deletion after used
The newly created memory is not being deleted and could cause memory overflow.
Thus, adding this "delete" to handle it and avoid overwritten memory.